### PR TITLE
Feature/add player movement

### DIFF
--- a/Scenes/Player/player_character.tscn
+++ b/Scenes/Player/player_character.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=6 format=3 uid="uid://0hu72lhq55rj"]
 
 [ext_resource type="Script" uid="uid://bxqt4q28fklk6" path="res://Scripts/Player/player_character.gd" id="1_uqtl7"]
-[ext_resource type="Texture2D" uid="uid://04uhhinjstq" path="res://_PrivateTestFolder/player_placeholder.png" id="2_1w75v"]
+[ext_resource type="Texture2D" uid="uid://dyf1qs30y6r2h" path="res://_PrivateTestFolder/player_placeholder.png" id="2_1w75v"]
 [ext_resource type="PackedScene" uid="uid://roml01bgklaf" path="res://Scenes/Commons/health_component.tscn" id="3_82a6j"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_xk7n3"]
@@ -11,10 +11,11 @@ height = 20.0
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_uqtl7"]
 size = Vector2(30, 30)
 
-[node name="CharacterBody2D" type="CharacterBody2D" node_paths=PackedStringArray("health_component")]
+[node name="CharacterBody2D" type="CharacterBody2D" node_paths=PackedStringArray("health_component", "sprite")]
 collision_mask = 0
 script = ExtResource("1_uqtl7")
 health_component = NodePath("PlayerHealthComponent")
+sprite = NodePath("Sprite2D")
 
 [node name="PhysicCollisionShape2D" type="CollisionShape2D" parent="." groups=["Enemies"]]
 shape = SubResource("CapsuleShape2D_xk7n3")

--- a/Scripts/Player/player_character.gd
+++ b/Scripts/Player/player_character.gd
@@ -4,7 +4,7 @@ class_name PlayerCharacter
 @export var health_component: HealthComponent
 
 @export var sprite : Sprite2D
-@export var base_step: float = .05   # base lunge distance
+@export var base_step: float = 100   # base lunge distance
 @export var lunge_time: float = 0.25  # how long the lunge lasts (seconds)
 
 var gravity : float = 1000 # default gravity value
@@ -34,7 +34,7 @@ func _ready() -> void:
 			)
 	#endregion
 
-	step_size = base_step * sprite.get_rect().size.x  # proportional to character's size
+	step_size = base_step * scale.x  # proportional to character's size
 	target_x = position.x
 
 func _physics_process(delta: float) -> void:

--- a/Scripts/Player/player_character.gd
+++ b/Scripts/Player/player_character.gd
@@ -3,6 +3,14 @@ class_name PlayerCharacter
 
 @export var health_component: HealthComponent
 
+@export var sprite : Sprite2D
+@export var base_step: float = .05   # base lunge distance
+@export var lunge_time: float = 0.25  # how long the lunge lasts (seconds)
+
+var gravity : float = 1000 # default gravity value
+var target_x: float # used to set relative x position for lunge
+var tween: Tween
+var is_lunging: bool = false
 var is_alive: bool = true:
 	# INFO Use the setter to trigger a signal if bool's value is false.
 	set(value):
@@ -12,7 +20,7 @@ var is_alive: bool = true:
 
 func _ready() -> void:
 	# INFO Change is_alive to false when the health from HealthComponent reaches 0.
-	# Using a lambda function.
+	# Using a lambda function. Sets player character's relative x position
 	health_component.health_depleted.connect(func change_is_alive() -> void: is_alive = false)
 	
 	#region DEBUG
@@ -25,6 +33,36 @@ func _ready() -> void:
 			)
 	#endregion
 
+	target_x = position.x
+
+func _physics_process(delta: float) -> void:
+	
+	var step_size : float = base_step * sprite.get_rect().size.x  # proportional to character's size
+
+	if not is_lunging:
+		if Input.is_action_just_pressed("attack_left"):
+			start_lunge(position.x - step_size, true)
+		elif Input.is_action_just_pressed("attack_right"):
+			start_lunge(position.x + step_size, false)
+
+	#velocity.y += gravity * delta
+	move_and_slide()
+
+func start_lunge(new_target: float, flip: bool) -> void:
+	#if tween and tween.is_running():
+		#tween.kill()  # cancel any ongoing tween
+
+	is_lunging = true
+	target_x = new_target
+
+	sprite.flip_h = flip
+
+	tween = create_tween()
+	tween.tween_property(self, "position:x", target_x, lunge_time) \
+		.set_trans(Tween.TRANS_EXPO) \
+		.set_ease(Tween.EASE_OUT)
+
+	tween.finished.connect(func _on_lunge_finished() -> void: is_lunging = false)
 
 func _input(event: InputEvent) -> void:
 	
@@ -34,7 +72,6 @@ func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("debug_action_2") and OS.is_debug_build():
 		health_component.heal_for(12)
 	#endregion
-
 
 func take_damage(value: int) -> void:
 	# NOTE The ennemies entities will trigger this function when they detect the

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="GWJ85"
 config/tags=PackedStringArray("jams")
-run/main_scene="uid://bbdjn6bbo8x47"
+run/main_scene="uid://bhdxqxiue8kd5"
 config/features=PackedStringArray("4.4", "GL Compatibility")
 config/icon="uid://dshcubd7jxq1e"
 
@@ -64,6 +64,16 @@ debug_action_1={
 debug_action_2={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":72,"key_label":0,"unicode":104,"location":0,"echo":false,"script":null)
+]
+}
+attack_left={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"location":0,"echo":false,"script":null)
+]
+}
+attack_right={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
 ]
 }
 


### PR DESCRIPTION
Extends player character behaviour:
- Add movement left to right that scales with main character scale(this can be changed to any other component)
- Movement accelerates the fastest at the start and sharply plateaus at the end of its movement using tween
- Queues any input from the client if they choose to attack again while in motion