### PR TITLE
Various UI resizes

### DIFF
--- a/Scenes/UI/credits.tscn
+++ b/Scenes/UI/credits.tscn
@@ -62,8 +62,8 @@ text = "Visual Assets"
 
 [node name="ArtNames" type="Label" parent="MarginContainer2/VBoxContainer"]
 layout_mode = 2
-text = "? Chloecats
-? Matilda"
+text = "Chloecats
+Matilda"
 horizontal_alignment = 1
 
 [node name="CodeCategory" type="Label" parent="MarginContainer2/VBoxContainer"]
@@ -82,7 +82,7 @@ text = "Sound Design and Music"
 
 [node name="MSNames" type="Label" parent="MarginContainer2/VBoxContainer"]
 layout_mode = 2
-text = "Mou ? ItzzStrike"
+text = "Mou"
 horizontal_alignment = 1
 
 [node name="HSeparator2" type="HSeparator" parent="MarginContainer2/VBoxContainer"]

--- a/Scenes/UI/game_over.tscn
+++ b/Scenes/UI/game_over.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=5 format=3 uid="uid://c5qiptme6derh"]
+[gd_scene load_steps=6 format=3 uid="uid://c5qiptme6derh"]
 
 [ext_resource type="Script" uid="uid://bqexqxlblrpwa" path="res://Scripts/UI/game_over.gd" id="1_jxkuk"]
 [ext_resource type="Texture2D" uid="uid://bw00kjm8tg4q" path="res://Assets/UI/T_button.png" id="2_w88jv"]
 [ext_resource type="Texture2D" uid="uid://cfe410el4kgdk" path="res://Assets/UI/T_button_pressed.png" id="3_ckxb7"]
 [ext_resource type="Texture2D" uid="uid://bamrfjhdibfj8" path="res://Assets/UI/T_button_hover.png" id="4_73uea"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_w88jv"]
+font_size = 50
 
 [node name="GameOver" type="Control" node_paths=PackedStringArray("retry_button")]
 process_mode = 2
@@ -30,27 +33,35 @@ anchors_preset = -1
 anchor_top = 0.2625
 anchor_right = 1.0
 anchor_bottom = 0.294444
-offset_top = 1.52588e-05
+offset_top = 11.0
+offset_bottom = 129.0
 grow_horizontal = 2
 grow_vertical = 2
 size_flags_horizontal = 4
-text = "You have been vanquished!"
+text = "You have been 
+VANQUISHED!"
+label_settings = SubResource("LabelSettings_w88jv")
 horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="RetryButton" type="TextureButton" parent="PanelContainer"]
 layout_mode = 2
-anchor_left = 0.448438
-anchor_top = 0.722222
-anchor_right = 0.550781
-anchor_bottom = 0.779167
+anchor_left = 0.428125
+anchor_top = 0.588889
+anchor_right = 0.563
+anchor_bottom = 0.664
+offset_left = 2.0
+offset_right = -39.64
+offset_bottom = -13.0796
+grow_horizontal = 2
+grow_vertical = 2
+scale = Vector2(1.32, 1.32)
 size_flags_horizontal = 6
 size_flags_vertical = 4
 texture_normal = ExtResource("2_w88jv")
 texture_pressed = ExtResource("3_ckxb7")
 texture_hover = ExtResource("4_73uea")
 texture_focused = ExtResource("4_73uea")
-metadata/_edit_use_anchors_ = true
 
 [node name="Label" type="Label" parent="PanelContainer/RetryButton"]
 layout_mode = 1

--- a/Scenes/UI/hud.tscn
+++ b/Scenes/UI/hud.tscn
@@ -20,6 +20,7 @@ pause_button = NodePath("PauseButton")
 [node name="Top" type="TextureRect" parent="."]
 layout_mode = 1
 anchors_preset = -1
+anchor_top = -0.00555556
 anchor_right = 1.0
 anchor_bottom = 0.0930556
 grow_horizontal = 2

--- a/Scenes/UI/main_menu.tscn
+++ b/Scenes/UI/main_menu.tscn
@@ -1,6 +1,14 @@
-[gd_scene load_steps=2 format=3 uid="uid://dglomjnvgatym"]
+[gd_scene load_steps=4 format=3 uid="uid://dglomjnvgatym"]
 
 [ext_resource type="Script" uid="uid://b0q7jfcpkbolf" path="res://Scripts/UI/main_menu.gd" id="1_i2xx2"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_5wsvm"]
+font_size = 60
+outline_size = 15
+outline_color = Color(0, 0, 0, 1)
+
+[sub_resource type="LabelSettings" id="LabelSettings_i2xx2"]
+font_size = 23
 
 [node name="MainMenu" type="Control" node_paths=PackedStringArray("play_button", "menu_panel")]
 layout_mode = 3
@@ -36,6 +44,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 0
 text = "GWJ85 TITLE"
+label_settings = SubResource("LabelSettings_5wsvm")
 horizontal_alignment = 1
 
 [node name="MarginContainer2" type="MarginContainer" parent="."]
@@ -64,5 +73,6 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 text = "Click on the screen to start playing!"
+label_settings = SubResource("LabelSettings_i2xx2")
 horizontal_alignment = 1
 vertical_alignment = 1

--- a/Scenes/UI/pause_menu.tscn
+++ b/Scenes/UI/pause_menu.tscn
@@ -231,7 +231,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
-text = "Save & Continue"
+text = "Continue"
 horizontal_alignment = 1
 vertical_alignment = 1
 


### PR DESCRIPTION
* Changed the size of the intro screen title and message so there's less dead space
* Added outline to the title so it sticks out more from the background (can be changed)
* Increased the size of the retry button and death text
* Removed the question marks from the credits
* Changed 'Save and Continue' to 'Continue' in the pause menu to avoid text overflow
* Slightly moved the HUD up to cover a gap at very top of the screen